### PR TITLE
refactor: simplify Docker deployment with unified PULL_POLICY approach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,6 @@ CLOUDFLARE_TUNNEL_TOKEN=your-cloudflare-tunnel-token
 DOCKER_IMAGE_NAME=sakanbeer88/sakumari
 DOCKER_IMAGE_TAG=latest
 CONTAINER_NAME_PREFIX=sakumari
+PULL_POLICY=always
 
 NODE_ENV=production

--- a/Makefile
+++ b/Makefile
@@ -14,34 +14,27 @@ DOCKER_DOWN_FLAGS = down -v --remove-orphans --rmi all
 IMAGE_NAME ?= sakanbeer88/sakumari
 TAG ?= latest
 
-# Docker Compose profiles (see docker-compose.yml for service definitions)
-# - build: Builds app from source code (development) - runs on port 3001
-# - prod: Uses pre-built image (production) - runs on port 3000  
-# - tunnel: Adds Cloudflare tunnel (production with external access)
-PROFILE_BUILD = --profile build
-PROFILE_PROD = --profile prod
-PROFILE_TUNNEL = --profile tunnel
-PROFILE_PROD_TUNNEL = $(PROFILE_PROD) $(PROFILE_TUNNEL)
+# Docker pull policy configuration
+# - build: Builds app from source code (local development)
+# - always: Pulls pre-built image from registry (production)
+PULL_POLICY_BUILD = PULL_POLICY=build
+PULL_POLICY_PROD = PULL_POLICY=always
 
 # -----------------------------------------------------------------------------
 # Helper Functions (Internal Use - Called by targets below)
 # -----------------------------------------------------------------------------
-define docker-profile-up
-	$(DOCKER_COMPOSE) $(1) up -d $(2)
+define docker-pull-policy-up
+	$(1) $(DOCKER_COMPOSE) up -d $(2)
 endef
 
-define docker-profile-down
-	$(DOCKER_COMPOSE) $(1) down
-endef
-
-define docker-profile-clean
-	$(DOCKER_COMPOSE) $(1) $(DOCKER_DOWN_FLAGS)
+define docker-tunnel-up
+	$(1) $(DOCKER_COMPOSE) --profile tunnel up -d $(2)
 endef
 
 define docker-db-setup-exec
-	$(DOCKER_COMPOSE) exec $(1) $(PNPM_PRISMA) generate && \
-	$(DOCKER_COMPOSE) exec $(1) $(PNPM_PRISMA) migrate deploy && \
-	$(DOCKER_COMPOSE) exec $(1) $(PNPM_PRISMA) db seed
+	$(DOCKER_COMPOSE) exec app $(PNPM_PRISMA) generate && \
+	$(DOCKER_COMPOSE) exec app $(PNPM_PRISMA) migrate deploy && \
+	$(DOCKER_COMPOSE) exec app $(PNPM_PRISMA) db seed
 endef
 
 # =============================================================================
@@ -119,42 +112,22 @@ docker-down:
 docker-clean:
 	$(DOCKER_COMPOSE) $(DOCKER_DOWN_FLAGS)
 
-# Application Deployment Profiles
+# Application Deployment with Pull Policy
 docker-up-build:
-	$(call docker-profile-up,$(PROFILE_BUILD),--build)
+	$(call docker-pull-policy-up,$(PULL_POLICY_BUILD))
 
 docker-up-prod:
-	$(call docker-profile-up,$(PROFILE_PROD))
+	$(call docker-pull-policy-up,$(PULL_POLICY_PROD))
+
+docker-up-build-tunnel:
+	$(call docker-tunnel-up,$(PULL_POLICY_BUILD))
 
 docker-up-prod-tunnel:
-	$(call docker-profile-up,$(PROFILE_PROD_TUNNEL))
+	$(call docker-tunnel-up,$(PULL_POLICY_PROD))
 
-# Stop specific profiles
-docker-down-build:
-	$(call docker-profile-down,$(PROFILE_BUILD))
-
-docker-down-prod:
-	$(call docker-profile-down,$(PROFILE_PROD))
-
-docker-down-prod-tunnel:
-	$(call docker-profile-down,$(PROFILE_PROD_TUNNEL))
-
-# Clean specific profiles (remove containers, volumes, images)
-docker-clean-build:
-	$(call docker-profile-clean,$(PROFILE_BUILD))
-
-docker-clean-prod:
-	$(call docker-profile-clean,$(PROFILE_PROD))
-
-docker-clean-prod-tunnel:
-	$(call docker-profile-clean,$(PROFILE_PROD_TUNNEL))
-
-# Database setup in containers
-docker-build-db-setup:
-	$(call docker-db-setup-exec,app-build)
-
+# Database setup in app container
 docker-db-setup:
-	$(call docker-db-setup-exec,app)
+	$(call docker-db-setup-exec)
 
 # Build Docker image
 docker-build:
@@ -163,6 +136,5 @@ docker-build:
 
 # Declare all targets as phony to prevent conflicts with files of the same name
 .PHONY: dev build lint format test-e2e test-all pre-ci generate migrate migrate-prod seed studio reset setup-db
-.PHONY: docker-up docker-down docker-clean docker-up-build docker-up-prod docker-up-prod-tunnel
-.PHONY: docker-down-build docker-down-prod docker-down-prod-tunnel docker-clean-build docker-clean-prod docker-clean-prod-tunnel
-.PHONY: docker-build-db-setup docker-db-setup docker-build
+.PHONY: docker-up docker-down docker-clean docker-up-build docker-up-prod docker-up-build-tunnel docker-up-prod-tunnel
+.PHONY: docker-db-setup docker-build

--- a/README.md
+++ b/README.md
@@ -161,32 +161,11 @@ pnpm run dev
 
 ### Full Stack Docker Deployment
 
-**Option 1: Build from source**
+**Option 1: Build from source (Local Development)**
 
 ```bash
 # Edit .env with your credentials (use POSTGRES_HOST=db for Docker networking)
-docker compose --profile build up -d
-
-# Database setup (run inside Docker container)
-docker compose exec app-build pnpm exec prisma generate
-docker compose exec app-build pnpm exec prisma migrate deploy
-docker compose exec app-build pnpm exec prisma db seed
-```
-
-- App runs on port 3001
-- Builds from local source code
-- Database setup runs inside the Docker container
-
-**Option 2: Production deployment**
-
-```bash
-# Edit .env with your credentials (use POSTGRES_HOST=db for Docker networking)
-
-# Production without tunnel
-docker compose --profile prod up -d
-
-# Production with Cloudflare tunnel
-docker compose --profile prod --profile tunnel up -d
+PULL_POLICY=build docker compose up -d
 
 # Database setup (run inside Docker container)
 docker compose exec app pnpm exec prisma generate
@@ -195,7 +174,28 @@ docker compose exec app pnpm exec prisma db seed
 ```
 
 - App runs on port 3000
-- Uses pre-built image
+- Builds from local source code
+- Database setup runs inside the Docker container
+
+**Option 2: Production deployment**
+
+```bash
+# Edit .env with your credentials (use POSTGRES_HOST=db for Docker networking)
+
+# Production without tunnel (default: PULL_POLICY=always)
+docker compose up -d
+
+# Production with Cloudflare tunnel
+docker compose --profile tunnel up -d
+
+# Database setup (run inside Docker container)
+docker compose exec app pnpm exec prisma generate
+docker compose exec app pnpm exec prisma migrate deploy
+docker compose exec app pnpm exec prisma db seed
+```
+
+- App runs on port 3000
+- Uses pre-built image from registry
 - Optional Cloudflare tunnel support
 - Database setup runs inside the Docker container
 
@@ -270,15 +270,15 @@ make reset                # Reset database (removes all data)
 make docker-up            # Start database and pgAdmin services
 make docker-down          # Stop all services
 make docker-clean         # Clean up Docker resources (volumes, images, orphans)
-make docker-up-build      # Build and run full stack from source
-make docker-up-prod       # Run production deployment (without tunnel)
-make docker-up-prod-tunnel # Run production deployment (with Cloudflare tunnel)
+make docker-up-build      # Build and run full stack from source (PULL_POLICY=build)
+make docker-up-prod       # Run production deployment (PULL_POLICY=always)
+make docker-up-build-tunnel  # Build and run with Cloudflare tunnel
+make docker-up-prod-tunnel   # Run production with Cloudflare tunnel
 make docker-build         # Build Docker image (default: sakumari:latest)
 ```
 
 ### Docker Database Setup
 
 ```bash
-make docker-build-db-setup  # Setup database for build profile
-make docker-db-setup        # Setup database for production profile
+make docker-db-setup      # Setup database in app container
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,13 @@ services:
     networks:
       - sakumari
 
-  # Production app service (prod profile)
+  # App service with dynamic pull policy
   app:
     image: ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+    pull_policy: ${PULL_POLICY:-always}
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: ${CONTAINER_NAME_PREFIX}-app
     ports:
       - "3000:3000"
@@ -58,34 +62,6 @@ services:
     user: "nextjs:nodejs"
     networks:
       - sakumari
-    profiles:
-      - prod
-
-  # Build from source service (build profile)
-  app-build:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: ${CONTAINER_NAME_PREFIX}-app-build
-    ports:
-      - "3001:3000"
-    environment:
-      NODE_ENV: production
-      POSTGRES_PRISMA_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      POSTGRES_URL_NON_POOLING: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      AUTH_URL: ${AUTH_URL}
-      AUTH_SECRET: ${AUTH_SECRET}
-      AUTH_GOOGLE_ID: ${AUTH_GOOGLE_ID}
-      AUTH_GOOGLE_SECRET: ${AUTH_GOOGLE_SECRET}
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: always
-    user: "nextjs:nodejs"
-    networks:
-      - sakumari
-    profiles:
-      - build
 
   # Cloudflare tunnel (tunnel profile only)
   cloudflared:


### PR DESCRIPTION
## Summary
• Removed separate app-build service and unified into single app service with dynamic pull policy
• Added PULL_POLICY environment variable to control build vs pull behavior (build for local dev, always for production)
• Simplified Makefile commands and removed profile-based deployment complexity
• Updated all documentation (README.md, CLAUDE.md) to reflect new streamlined approach
• Single service now runs on port 3000 for both development and production deployments